### PR TITLE
Replacing Unicode char in Modulefile with similar ASCII one

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,6 +1,6 @@
 name "blom-rssh"
 version "0.0.3"
-author "Ørjan Blom"
+author "Orjan Blom"
 project_page "https://github.com/blom/puppet-rssh"
 source "https://github.com/blom/puppet-rssh"
 license "ISC"


### PR DESCRIPTION
Puppet on ubuntu trusty fails with noticing there non-ASCII char present in resulted
metadata.json. So removing it to ASCII one.

Ørjan, sorry but It's required to use it by installing from puppet forge.

Signed-off-by: Igor Shishkin me@teran.ru
